### PR TITLE
updating botkit version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "license": "ISC",
   "dependencies": {
-    "beepboop-botkit": "^1.1.1",
-    "botkit": "0.0.14"
+    "beepboop-botkit": "^1.4.1",
+    "botkit": "0.2.1"
   },
   "engines": {
     "node": "4.2.3"


### PR DESCRIPTION
Bumping up the `botkit` to take advantage of a bug fix for reconnect issues.  Bot's would run for a few days, then disconnect, and not reconnect w/o a manual restart.
