### PR TITLE
adds existence check - sometimes isn't set

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ var getStoryAttachment = function(story) {
     var storyDate = story['storytimeago_value'];
     var comments = story['commentcount_link/_text'];
     var commentsLink = story['commentcount_link'];
-    var votes = story['storyvoteis_number'][0];
+    var votes = (story['storyvoteis_number'] && story['storyvoteis_number'][0]) || 0;
     var attachmentColour = getAttachmentColour(title);
 
     var attachment = {


### PR DESCRIPTION
Noticed the bot was crashing from the property `storyvoteis_number` sometimes missing.  Doing an existence check and default to `0` to prevent that.